### PR TITLE
(COMPLETE) Progressing with reduce and map.update

### DIFF
--- a/exercises/weighted_voting.livemd
+++ b/exercises/weighted_voting.livemd
@@ -79,7 +79,20 @@ defmodule WeightedVoting do
     iex> WeightedVoting.count([cats: 10, dogs: 20, dogs: 10, cats: 30], :cats)
     40
   """
+
+  # input: keyword list & a key
+  # output: a number -> the total number of votes for such key
+  # The problem -> account for the values of such key, ignore the values of other keys
+  # and add to the accumulator
+
   def count(votes, vote_to_count) do
+    Enum.reduce(votes, 0, fn {key, value}, acc ->
+      if key == :cats do
+        acc = acc + value
+      else
+        acc
+      end
+    end)
   end
 
   @doc """
@@ -97,9 +110,41 @@ defmodule WeightedVoting do
     iex> WeightedVoting.tally([cats: 10, dogs: 20, cats: 20, dogs: 10, birds: 20])
     [birds: 20, cats: 30, dogs: 30]
   """
+
+  # input: keyword list with animal: votes
+  # output: keyword list with animal: total votes, in alphabetical order
+  # solution: 
+  # check the item
+  # if it already exists in the final keyword list, add the number of votes
+  # if it doesn't exist, add a new key and value
+  # when finished with reading, order alphabetically
+  # return
+
   def tally(votes) do
+    Enum.reduce(votes, [], fn {animal, number}, new_list ->
+      if(Enum.member?(new_list, animal))
+
+      List.replace_at(new_list, index, {animal, value})
+    end)
+
+    # List.keysort(final_list, 0, :asc) - This works but is out of scope 
   end
 end
+
+WeightedVoting.count([cats: 10, dogs: 20, dogs: 10, cats: 30], :cats)
+```
+
+```elixir
+# def tally(votes) do
+#   Enum.reduce(votes, [], fn {animal, number}, final_list -> 
+#     final_list = [{animal, number} | final_list ]
+
+#   end)
+#   
+#   end
+# end
+
+WeightedVoting2.tally(cats: 10, dogs: 20, cats: 20, dogs: 10, birds: 20)
 ```
 
 ## Commit Your Progress


### PR DESCRIPTION
Hello @BrooklinJazz

A few questions on WeighterVoting

This syntax seems to work
![image](https://user-images.githubusercontent.com/113518695/194046370-ce4a0528-b7a4-4f56-9a9f-d726aaebe7fb.png)


And this raises a compile error
![image](https://user-images.githubusercontent.com/113518695/194046414-fbd1cffc-549a-4a4b-98c2-1e65202ebcc9.png)


Maybe I am missing something in the use of -> vs do?

I do not understand why the solution proposed uses {} instead of [], since the result is supposed to be accumulated into a list, not a map? I assume map is chosen because of the way we can manipulate data within a map?

If the final keyword list needs to be delivered in alphabetical order, I thought "List.keysort(final_list, 0, :asc)" would work, but since I place it ouside of Enum it raises the error of being out of scope.

I've been hitting some roadbloacks. Checking the solution suggested is useful, though it leaves a few doubts:

- Am I correct in understanding that map is chosen over lists because we can reference a value by key?
- The function Map.update already does the "finding", instead of having to apply a filter on enum or a comprehension?
- Is the solution accounting for the ordering alphabetically? If so, is that something that maps do automatically, order themselves alphabetically?

Thank you!

